### PR TITLE
✨FEAT : Current Weather 기능 구현 + 약간의 CSS 레이아웃 수정

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,12 @@
+body {
+  margin: 0;
+}
+
+#root {
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/components/Japan/Exchange.jsx
+++ b/src/components/Japan/Exchange.jsx
@@ -1,17 +1,14 @@
 import { useEffect, useState } from 'react';
-import './JapanDefaultLayout.css';
 
 function Exchange() {
-  const apiKey = import.meta.env.VITE_EXCHANGE_APIKEY;
   const [krwToJpy, setKrwToJpy] = useState(0);
   const [jpyToKrw, setJpyToKrw] = useState(0);
   const [isKrwToJpy, setIsKrwToJpy] = useState(true);
+  const apiKey = import.meta.env.VITE_EXCHANGE_API_KEY;
 
   // 1엔이 한화로 몇 원인지를 구해주는 함수
   async function getKrwToJpyExchange() {
-    const response = await fetch(
-      `https://v6.exchangerate-api.com/v6/${apiKey}/pair/jpy/krw`
-    );
+    const response = await fetch(`https://v6.exchangerate-api.com/v6/${apiKey}/pair/jpy/krw`);
     const exchangeData = await response.json();
 
     setKrwToJpy(exchangeData);
@@ -19,9 +16,7 @@ function Exchange() {
 
   // 한화 1원이 일본화로 몇엔에 해당하는지를 구해주는 함수
   async function getJpyToKrwExchange() {
-    const response = await fetch(
-      `https://v6.exchangerate-api.com/v6/${apiKey}/pair/krw/jpy`
-    );
+    const response = await fetch(`https://v6.exchangerate-api.com/v6/${apiKey}/pair/krw/jpy`);
     const exchangeData = await response.json();
 
     setJpyToKrw(exchangeData);
@@ -41,11 +36,7 @@ function Exchange() {
     <div className='exchange-outer-div'>
       <div>일본 환율 화면입니다</div>
       <div className='real-exchangeRate' onClick={handleChangeKrwJpy}>
-        {isKrwToJpy === true ? (
-          <div>{krwToJpy['conversion_rate']}</div>
-        ) : (
-          <div>{jpyToKrw['conversion_rate']}</div>
-        )}
+        {isKrwToJpy === true ? <div>{krwToJpy['conversion_rate']}</div> : <div>{jpyToKrw['conversion_rate']}</div>}
       </div>
     </div>
   );

--- a/src/components/Japan/JapanDefaultLayout.css
+++ b/src/components/Japan/JapanDefaultLayout.css
@@ -1,5 +1,5 @@
 .jp-default-layout {
-  width: 740px;
+  width: 480px;
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -9,7 +9,7 @@
 }
 
 .japan-navbar {
-  width: 740px;
+  width: 480px;
   display: flex;
   justify-content: center;
   border: 3px solid red;

--- a/src/components/Japan/JapanDefaultLayout.css
+++ b/src/components/Japan/JapanDefaultLayout.css
@@ -1,15 +1,29 @@
+.jp-default-layout {
+  width: 740px;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border: 3px solid red;
+}
+
+.japan-navbar {
+  width: 740px;
+  display: flex;
+  justify-content: center;
+  border: 3px solid red;
+  position: absolute;
+  bottom: 0;
+}
+
 .exchange-outer-div {
   width: 100%;
-  height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-}
-
-.japan-navbar {
-  margin-bottom: 20px;
-  padding-bottom: 20px;
 }
 
 .real-exchangeRate {

--- a/src/components/Japan/JpDefaultLayout.jsx
+++ b/src/components/Japan/JpDefaultLayout.jsx
@@ -1,12 +1,13 @@
+import './JapanDefaultLayout.css';
 import { Outlet } from 'react-router-dom';
 import JpNavBar from './JpNavBar';
 
 function JpDefaultLayout() {
   return (
-    <>
-      <JpNavBar />
+    <div className='jp-default-layout'>
       <Outlet />
-    </>
+      <JpNavBar />
+    </div>
   );
 }
 

--- a/src/components/Japan/JpWeather.jsx
+++ b/src/components/Japan/JpWeather.jsx
@@ -1,5 +1,75 @@
+import { useState } from 'react';
+
 function JpWeather() {
-  return <div>일본 날씨입니다</div>;
+  const [weatherData, setWeatherData] = useState('');
+  const [city, setCity] = useState('');
+
+  const cities = {
+    kr: ['오사카', '교토', '고베', '도쿄', '하코네', '요코하마', '후쿠오카', '유후인', '기타큐슈', '삿포로'],
+    us: ['osaka', 'kyoto', 'kobe', 'tokyo', 'hakone', 'yokohama', 'fukuoka', 'yufuin', 'kitakyushu', 'sapporo'],
+  };
+
+  const currentDate = () => {
+    const today = new Date();
+    return `${today.getMonth() + 1}월 ${today.getDate()}일`;
+  };
+
+  const options = {
+    method: 'GET',
+    headers: {
+      'X-RapidAPI-Key': import.meta.env.VITE_WEATHER_API_KEY,
+      'X-RapidAPI-Host': 'weatherapi-com.p.rapidapi.com',
+    },
+  };
+
+  const fetchWeatherData = async (e) => {
+    const url = `https://weatherapi-com.p.rapidapi.com/current.json?q=${e}`;
+    try {
+      const response = await fetch(url, options);
+      const result = await response.json();
+      setWeatherData(result);
+      console.log(result);
+    } catch (error) {
+      setWeatherData(null);
+      setError(error.message);
+    }
+  };
+
+  return (
+    <div className='weather'>
+      <h1>일본 날씨입니다</h1>
+      <div className='weather-current'>현재 날씨</div>
+      <div>
+        {weatherData && (
+          <div>
+            <h2>{city}</h2>
+            <img src={weatherData.current.condition.icon}></img>
+            <p>{weatherData.current.feelslike_c}</p>
+            <p>{weatherData.current.condition.text}</p>
+          </div>
+        )}
+      </div>
+      <h2>{currentDate()} 날씨입니다</h2>
+      <ul className='weather-day'>
+        <li className='weather-time'></li>
+      </ul>
+
+      <ul className='weather-where'>
+        {cities.kr.map((krCity, index) => (
+          <li
+            className='weather-city'
+            key={krCity}
+            onClick={(e) => {
+              setCity(e.target.innerText);
+              fetchWeatherData(cities.us[index]);
+            }}
+          >
+            {krCity}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }
 
 export default JpWeather;

--- a/src/components/Korea/KoreaDefaultLayout.css
+++ b/src/components/Korea/KoreaDefaultLayout.css
@@ -1,5 +1,5 @@
 .kr-default-layout {
-  width: 740px;
+  width: 480px;
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -9,7 +9,7 @@
 }
 
 .korea-navbar {
-  width: 740px;
+  width: 480px;
   display: flex;
   justify-content: center;
   border: 3px solid red;

--- a/src/components/Korea/KoreaDefaultLayout.css
+++ b/src/components/Korea/KoreaDefaultLayout.css
@@ -1,0 +1,18 @@
+.kr-default-layout {
+  width: 740px;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border: 3px solid red;
+}
+
+.korea-navbar {
+  width: 740px;
+  display: flex;
+  justify-content: center;
+  border: 3px solid red;
+  position: absolute;
+  bottom: 0;
+}

--- a/src/components/Korea/KrDefaultLayout.jsx
+++ b/src/components/Korea/KrDefaultLayout.jsx
@@ -1,12 +1,13 @@
+import './KoreaDefaultLayout.css';
 import { Outlet } from 'react-router-dom';
 import KrNavBar from './KrNavBar';
 
 function KrDefaultLayout() {
   return (
-    <>
-      <KrNavBar />
+    <div className='kr-default-layout'>
       <Outlet />
-    </>
+      <KrNavBar />
+    </div>
   );
 }
 

--- a/src/components/Korea/KrNavBar.jsx
+++ b/src/components/Korea/KrNavBar.jsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 
 function KrNavBar() {
   return (
-    <header>
+    <header className='korea-navbar'>
       <nav>
         <Link to='/'>Home</Link>
         <Link to='korea/weather'>날씨</Link>

--- a/src/components/Korea/KrWeather.jsx
+++ b/src/components/Korea/KrWeather.jsx
@@ -1,5 +1,75 @@
+import { useState } from 'react';
+
 function KrWeather() {
-  return <div>한국 날씨입니다</div>;
+  const [weatherData, setWeatherData] = useState('');
+  const [city, setCity] = useState('');
+
+  const cities = {
+    kr: ['서울', '부산', '제주', '양양', '전주', '대전', '광주', '여수', '강릉', '속초'],
+    us: ['Seoul', 'Busan', 'Jeju', 'Yangyang', 'Jeonju', 'Daejeon', 'Gwangju', 'Yeosu', 'Gangneung', 'Sokcho'],
+  };
+
+  const currentDate = () => {
+    const today = new Date();
+    return `${today.getMonth() + 1}월 ${today.getDate()}일`;
+  };
+
+  const options = {
+    method: 'GET',
+    headers: {
+      'X-RapidAPI-Key': import.meta.env.VITE_WEATHER_API_KEY,
+      'X-RapidAPI-Host': 'weatherapi-com.p.rapidapi.com',
+    },
+  };
+
+  const fetchWeatherData = async (e) => {
+    const url = `https://weatherapi-com.p.rapidapi.com/current.json?q=${e}`;
+    try {
+      const response = await fetch(url, options);
+      const result = await response.json();
+      setWeatherData(result);
+      console.log(result);
+    } catch (error) {
+      setWeatherData(null);
+      setError(error.message);
+    }
+  };
+
+  return (
+    <div className='weather'>
+      <h1>한국 날씨입니다</h1>
+      <div className='weather-current'>현재 날씨</div>
+      <div>
+        {weatherData && (
+          <div>
+            <h2>{city}</h2>
+            <img src={weatherData.current.condition.icon}></img>
+            <p>{weatherData.current.feelslike_c}</p>
+            <p>{weatherData.current.condition.text}</p>
+          </div>
+        )}
+      </div>
+      <h2>{currentDate()} 날씨입니다</h2>
+      <ul className='weather-day'>
+        <li className='weather-time'></li>
+      </ul>
+
+      <ul className='weather-where'>
+        {cities.kr.map((krCity, index) => (
+          <li
+            className='weather-city'
+            key={krCity}
+            onClick={(e) => {
+              setCity(e.target.innerText);
+              fetchWeatherData(cities.us[index]);
+            }}
+          >
+            {krCity}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }
 
 export default KrWeather;

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,0 @@
-#root {
-  width: 100%;
-  height: 100%;
-}


### PR DESCRIPTION
![화면 기록 2023-10-15 오전 6 20 56](https://github.com/2-guys-Javascript/travel-web-app/assets/130689753/d667bf37-2005-4484-a80c-37c7e75e4944)

# 🌦️ 현재 날씨 기능 추가
WeatherAPI를 활용하여 위치에 따른 현재의 날씨 정보를 받아오도록 기능 추가하였습니다!
아이콘은 현재 API에서 기본 제공하는 icon을 활용하고 있지만, 추후에 변경할 예정이고 날씨 관련 기능 중 추가할 예정인 기능은 IPhone 내장 날씨앱과 같은 현재 시간부터 앞으로의 24시간의 기온과 날씨 예보를 추가할 계획입니다! 내일까지 가능할지는 모르겠지만,,, 해볼게요!! 📝

🍟 API key는 노션에 공유했습니다! 아 그리고 gitignore APIKEY 로 되어있던 거 API_KEY로 수정했습니다! 파란색 밑줄 자꾸떠서 거슬려서 수정함

# 🎨 CSS 수정
_**각 담당하는 부분(layout, nav)의 구분도를 위해 빨간색 solid border-box를 줬습니다!**_
또한 [캐치테이블](https://app.catchtable.co.kr/)의 화면처럼 세로 고정값을 주고(480px 줘야하는건데 실수로 740px 줬네요 수정해서 추가로 커밋했습니다!) body태그에 마진값을 0으로 변경, default-layout의 height: 100vh로 설정해 좀 더 모바일 디바이스 환경에서 불편함이 없도록 수정하였습니다!


<img width="269" alt="스크린샷 2023-10-15 오전 6 36 29" src="https://github.com/2-guys-Javascript/travel-web-app/assets/130689753/1ec713a2-fbbb-4be4-8834-eda77d370483">


🍟 승완님 기존에 작성하셨던 CSS 코드 약간의 수정사항 있습니다! 기존에 width: 100vw 주셨던 것 스크롤바 생기는 문제 때문에 100%로 레이아웃에 맞게 수정하였습니다! 
commit 내역 확인해보셔도 괜찮고, 직접 코드 비교해보심이 좋을 듯 합니다!