### PR TITLE
🎨STYLE: 모바일 디바이스 맞춤 화면 수정

### DIFF
--- a/src/components/Japan/JapanDefaultLayout.css
+++ b/src/components/Japan/JapanDefaultLayout.css
@@ -1,7 +1,7 @@
 .jp-default-layout {
   max-width: 480px;
   width: 100vw;
-  height: 100%;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -9,6 +9,7 @@
   border: 3px solid red;
   overflow-y: auto;
   padding-bottom: 60px;
+  box-shadow: 0 0 20px #00000033;
 }
 
 .japan-footer {

--- a/src/components/Korea/KoreaDefaultLayout.css
+++ b/src/components/Korea/KoreaDefaultLayout.css
@@ -2,7 +2,7 @@
   max-width: 480px;
   width: 100vw;
   /* 최대의 가로 사이즈 480px / 화면이 더 작을때는 100vw를 주어 반응형 디자인을 구현하였습니다 */
-  height: 100%;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -12,6 +12,7 @@
   /* 최대 길이에 맞춰 스크롤이 작동하도록 했습니다 */
   padding-bottom: 60px;
   /* navbar가 화면에 보일 수 있는 여유를 줬습니다 */
+  box-shadow: 0 0 20px #00000033;
 }
 
 .korea-footer {

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 body {
   margin: 0;
+  overflow: hidden;
 }
 
 /* css #root의 css값 수정했습니다! 모바일 화면 최적화 */


### PR DESCRIPTION
# 🎨 CSS 수정

소량의 수정이 있었습니다!

<img width="952" alt="스크린샷 2023-10-17 오후 8 41 40" src="https://github.com/2-guys-Javascript/travel-web-app/assets/130689753/b445e522-a7c5-4404-b782-0a56554be04e">

모바일 환경에 맞춘 디자인으로 웹으로 접속시에도 모바일 환경과 같은 세팅으로 동작하기 때문에 box-shadow로 그림자 효과를 줘 딱 맞는 모바일 환경에서는 보이지 않지만, 웹으로 접속 시 구분감을 느낄 수 있게 했습니다!
그리고 height 를 100% => 100hv 로 바꿔줬습니다!

<img width="777" alt="스크린샷 2023-10-17 오후 8 42 09" src="https://github.com/2-guys-Javascript/travel-web-app/assets/130689753/191c1fee-e94f-4d8b-96cb-ed1d82158a3f">

스크롤이 발생하지는 않지만 혹시나 발생 할 수 있는 불필요한 요소를 줄이고자 overflow: hidden 했습니다!