### PR TITLE
🎨 Styles: change footer and exchangeRate component UI

### DIFF
--- a/src/components/Japan/Exchange.jsx
+++ b/src/components/Japan/Exchange.jsx
@@ -42,12 +42,16 @@ function Exchange() {
 
   return (
     <div className='exchange-outer-div'>
-      <div>일본 환율 화면입니다</div>
+      <h2 className='exchange-description'>일본 환율 화면입니다</h2>
       <div className='real-exchangeRate' onClick={handleChangeKrwJpy}>
+        <div>Click here to change a base currency
+          <h4 className='base-currency'>Base currency is {isKrwToJpy === true? 'Yen': 'Won'}</h4>
+        </div>
+        <h2>{isKrwToJpy === true ? `${krwToJpy['conversion_rate']}₩` : `${jpyToKrw['conversion_rate']}¥`}</h2>
         {isKrwToJpy === true ? (
-          <div>{krwToJpy['conversion_rate']}</div>
+          <div>1 Yen is equal to {krwToJpy['conversion_rate']} Won</div>
         ) : (
-          <div>{jpyToKrw['conversion_rate']}</div>
+          <div>1 Won is equal to {jpyToKrw['conversion_rate']} Yen</div>
         )}
       </div>
     </div>

--- a/src/components/Japan/JapanDefaultLayout.css
+++ b/src/components/Japan/JapanDefaultLayout.css
@@ -8,22 +8,25 @@
   align-items: center;
   border: 3px solid red;
   overflow-y: auto;
-  padding-bottom: 60px;
   box-shadow: 0 0 20px #00000033;
 }
 
 .japan-footer {
+  border: 3px solid red;
   position: fixed;
+  display: flex;
+  align-items: center;
   bottom: 0;
+  height: 10vh;
   z-index: 99;
 }
 
 .japan-navbar {
-  border: 3px solid red;
   max-width: 480px;
   width: 100vw;
   display: flex;
   justify-content: space-around;
+  align-items: center;
   box-sizing: border-box;
   height: 48px;
 }
@@ -69,18 +72,29 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: space-evenly;
   align-items: center;
 }
 
 .real-exchangeRate {
-  position: relative;
-  bottom: 250px;
-  padding: 150px;
-  margin: 150px;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  width: 80%;
+  height: 50%;
   border: 1px solid black;
+  border-radius: 10%;
+  flex-direction: column;
+}
+
+.real-exchangeRate:hover {
+  box-shadow: 0px 0px 30px #f7bee7;
 }
 
 .real-exchangeRate:hover {
   cursor: pointer;
+}
+
+.base-currency {
+  text-align: center;
 }

--- a/src/components/Japan/JpWeather/JpWeather.jsx
+++ b/src/components/Japan/JpWeather/JpWeather.jsx
@@ -43,7 +43,7 @@ function JpWeather() {
 
   return (
     <div className='weather'>
-      <h1>일본 날씨입니다</h1>
+      <h2>일본 날씨입니다</h2>
       <div className='weather-current'>현재 날씨</div>
       <div>
         {weatherData && (

--- a/src/components/Korea/KoreaDefaultLayout.css
+++ b/src/components/Korea/KoreaDefaultLayout.css
@@ -10,26 +10,29 @@
   border: 3px solid red;
   overflow-y: auto;
   /* 최대 길이에 맞춰 스크롤이 작동하도록 했습니다 */
-  padding-bottom: 60px;
   /* navbar가 화면에 보일 수 있는 여유를 줬습니다 */
   box-shadow: 0 0 20px #00000033;
 }
 
 .korea-footer {
+  border: 3px solid red;
   position: fixed;
+  display: flex;
   /* 위치 고정 */
   bottom: 0;
   z-index: 99;
+  height: 10vh;
+  align-items: center;
   /* 최상단 표시 */
 }
 
 .korea-navbar {
-  border: 3px solid red;
   max-width: 480px;
   width: 100vw;
   /* default layout과 동일하게 최대너비와 반응형 넓이를 줬습니다 */
   display: flex;
   justify-content: space-around;
+  align-items: center;
   box-sizing: border-box;
   height: 48px;
 }

--- a/src/components/Korea/KrWeather/KrWeather.jsx
+++ b/src/components/Korea/KrWeather/KrWeather.jsx
@@ -42,7 +42,7 @@ function KrWeather() {
 
   return (
     <div className='weather'>
-      <h1>한국 날씨입니다</h1>
+      <h2>한국 날씨입니다</h2>
       <div className='weather-current'>현재 날씨</div>
       <div>
         {weatherData && (

--- a/src/index.css
+++ b/src/index.css
@@ -17,4 +17,5 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-bottom: 90px;
 }


### PR DESCRIPTION
![영상1](https://github.com/2-guys-Javascript/travel-web-app/assets/125981945/8f4dd974-9af4-401c-a19a-4345cd45e590)
footer의 변경 및 exchangeRate(환율) 컴포넌트 변경에 관한 pr입니다. 코드 보신 후 피드백 주시면 감사하겠습니다! 

1. 먼저 기존의 날씨(`weather`) 컴포넌트에서 텍스트가 `h1`이던 부분을 `h2`로 바꾸어주었습니다. 이는 Home 컴포넌트의 h1과 같아 의도치 않은 색 효과를 가졌던 것을 해결했습니다. 추후에 h2 컴포넌트들을 사용할 때 class selector 방식으로 스타일링하면 좋을 듯합니다!
2. 이전 코드에서 footer가 좀 작다는 느낌이 있었습니다. 구조를 보면 footer 안에 nav가 있고 그 안에 각 페이지로 이동할 수 있는 a 태그들이 있습니다. nav 요소만 `display: flex` 속성이 있었지만, footer 요소에도 `display: flex` 를 주었습니다. 그리고 빨간색 border는 nav 태그에서 footer 로 이동시켰습니다. 이들을 깔끔하게 보이게 하기 위한 flex box 속성도 설정했습니다( 앱을 실행시켜서 UI 확인해보시는 것 정도로 하셔도 좋을 것 같습니다). `japan-footer`와 `korea-footer` 요소들의 `height`를 적당히 10vh로 설정하여 모바일 환경에서도 어느 정도 느낌이 비슷하게 처리해 주었습니다.
3. japan과 korea 탭의 layout 컴포넌트에서 padding-bottom 속성 주신 것을 빼고 index.css에서 weather 클래스에 padding-bottom을 적용해 주었습니다. 
4. exchange 컴포넌트에서 div를 클릭했을 때, `box-shadow` 효과를 주었습니다. 관련 색상과 데코레이션은 나중에 앱을 꾸밀때 진행해도 될 것 같습니다. 다만 exchange 컴포넌트는 `useEffect()` 훅을 이용해 원화와 엔화에 대한 환율을 컴포넌트의 마운트 시 받아오는데, 이는 비동기적인 작업이므로 앱을 실행시켜보시면 아주 잠깐 undefined UI가 나타납니다. 이를 해결하는 방안도 고민해보도록 하겠습니다.
5. **추가** : 날씨 탭에서 특정 도시를 클릭했을 때, footer 부분이 살짝 왼쪽으로 다 같이 밀려나는 현상이 있습니다. 뭐 지금 이거에 매몰될 필요는 없을 것 같은데, 나중에 고민해봐도 좋을 것 같습니다!


오늘 하루도 고생 정말 많으셨습니다!
