### PR TITLE
✨FEAT : 날씨 3일 예보 + CSS 스타일링 수정

### DIFF
--- a/src/components/Japan/JapanDefaultLayout.css
+++ b/src/components/Japan/JapanDefaultLayout.css
@@ -4,21 +4,21 @@
   height: 100vh;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
-  border: 3px solid red;
   overflow-y: auto;
   box-shadow: 0 0 20px #00000033;
 }
 
 .japan-footer {
-  border: 3px solid red;
   position: fixed;
   display: flex;
   align-items: center;
   bottom: 0;
   height: 10vh;
   z-index: 99;
+  background-color: #ffffff;
+  box-shadow: 0 0 5px #00000033;
 }
 
 .japan-navbar {
@@ -37,23 +37,78 @@
   text-align: center;
 }
 
-.japan-weather-hourly {
-  display: flex;
-  flex-direction: row;
-  padding: 0;
-  margin: 0;
-  border: 2px solid red;
+.jp-weather-text-div {
   max-width: 480px;
   width: 100vw;
+  text-align: center;
+  border-radius: 25px;
+}
+
+.jp-weather-text1 {
+  color: #ffa7fce7;
+  font-size: 30px;
+  font-weight: 400;
+  margin-top: 40px;
+  margin-bottom: 0;
+}
+
+.jp-weather-text2 {
+  color: #0000009e;
+  font-size: 18px;
+  font-weight: 500;
+  margin-top: 5px;
+}
+
+.jp-weather-current {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.jp-weather-current .city {
+  font-size: 38px;
+  font-weight: 400;
+}
+
+.jp-weather-current .c {
+  font-size: 68px;
+  margin: 0;
+  font-weight: 500;
+}
+
+.jp-weather-current .text {
+  font-size: 18px;
+  text-transform: uppercase;
+  color: #00000055;
+}
+
+.japan-weather-hourly {
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: row;
+  padding: 0px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  margin: 0;
+  max-width: 460px;
+  width: 95vw;
   box-sizing: border-box;
   height: 100px;
   text-align: center;
   flex-wrap: nowrap;
   overflow-y: hidden;
   overflow-x: auto;
+  list-style-type: none;
+  border-radius: 15px;
+  box-shadow: 0 0 5px #00000033;
 }
 
-.japan-weather-hourly div {
+.japan-weather-hourly li {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
   flex: 0 0 auto;
   margin: 10px;
 }
@@ -63,8 +118,79 @@
 }
 
 .japan-weather-hourly-icon {
-  width: 42px;
-  height: 42px;
+  width: 38px;
+}
+
+.japan-forecast {
+  background-color: #ffffff;
+  padding: 0;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  max-width: 460px;
+  width: 95vw;
+  list-style-type: none;
+  display: flex;
+  flex-direction: column;
+  border-radius: 15px;
+  box-shadow: 0 0 5px #00000033;
+}
+
+.japan-forecast li {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  border-bottom: 1px solid #00000013;
+}
+
+.japan-forecast .last {
+  border-bottom: none;
+}
+
+.japan-forecast img {
+  width: 28px;
+}
+
+.jp-weather-where-container {
+  max-width: 480px;
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-radius: 25px;
+}
+
+.jp-where {
+  color: #ff8cdcf8;
+  font-weight: 400;
+  text-align: center;
+}
+
+.jp-weather-where {
+  padding: 0;
+  max-width: 460px;
+  width: 95vw;
+  list-style-type: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.jp-weather-city {
+  background-color: #ffffff;
+  text-align: center;
+  font-size: 20px;
+  font-weight: 400;
+  color: #000000;
+  border-radius: 18px;
+  box-shadow: 0 0 3px #00000033;
+  margin: 7px 10px;
+  padding: 8px 18px;
+  cursor: pointer;
+}
+
+.jp-weather-city:hover {
+  background-color: #00000018;
+  transition: 0.5s;
 }
 
 .exchange-outer-div {

--- a/src/components/Japan/JpWeather/JpForecastWeather.jsx
+++ b/src/components/Japan/JpWeather/JpForecastWeather.jsx
@@ -1,5 +1,30 @@
-function JpForecastWeather() {
-  return <div>JpForecastWeather</div>;
+function JpForecastWeather({ days }) {
+  if (days === '') {
+    return null;
+  }
+
+  return (
+    <ul className='japan-forecast'>
+      <li>
+        <span>오늘</span>
+        <img src={days[0].day.condition.icon}></img>
+        <span>{days[0].day.mintemp_c}°</span>
+        <span>{days[0].day.maxtemp_c}°</span>
+      </li>
+      <li>
+        <span>내일</span>
+        <img src={days[1].day.condition.icon}></img>
+        <span>{days[1].day.mintemp_c}°</span>
+        <span>{days[1].day.maxtemp_c}°</span>
+      </li>
+      <li className='last'>
+        <span>모래</span>
+        <img src={days[2].day.condition.icon}></img>
+        <span>{days[2].day.mintemp_c}°</span>
+        <span>{days[2].day.maxtemp_c}°</span>
+      </li>
+    </ul>
+  );
 }
 
 export default JpForecastWeather;

--- a/src/components/Japan/JpWeather/JpHourlyWeather.jsx
+++ b/src/components/Japan/JpWeather/JpHourlyWeather.jsx
@@ -7,9 +7,9 @@ function JpHourlyWeather({ days }) {
     <ul className='japan-weather-hourly'>
       {days[0].hour.map((hour) => (
         <li key={hour.time.slice(10, 13)}>
+          <p> {hour.time.slice(10, 13)}시 </p>
           <img className='japan-weather-hourly-icon' src={hour.condition.icon} />
-          <p> {hour.feelslike_c} </p>
-          <p> {hour.time.slice(10, 16)} </p>
+          <p> {hour.feelslike_c}° </p>
         </li>
       ))}
     </ul>

--- a/src/components/Japan/JpWeather/JpWeather.jsx
+++ b/src/components/Japan/JpWeather/JpWeather.jsx
@@ -35,6 +35,7 @@ function JpWeather() {
       const result = await response.json();
       setWeatherData(result);
       setForecast(result.forecast.forecastday.map((day) => day));
+      console.log(result.forecast.forecastday.map((day) => day));
     } catch (error) {
       setWeatherData(null);
       console.error(error);
@@ -43,36 +44,38 @@ function JpWeather() {
 
   return (
     <div className='weather'>
-      <h2>일본 날씨입니다</h2>
-      <div className='weather-current'>현재 날씨</div>
+      <div className='jp-weather-text-div'>
+        <h2 className='jp-weather-text1'>일본</h2>
+        <h2 className='jp-weather-text2'>{weatherData && `${currentDate()} 날씨`}</h2>
+      </div>
       <div>
         {weatherData && (
-          <div>
-            <h2>{city}</h2>
-            <img src={weatherData.current.condition.icon}></img>
-            <p>{weatherData.current.feelslike_c}</p>
-            <p>{weatherData.current.condition.text}</p>
+          <div className='jp-weather-current'>
+            <h2 className='city'>{city}</h2>
+            <p className='c'>{weatherData.current.feelslike_c}°</p>
+            <p className='text'>{weatherData.current.condition.text}</p>
           </div>
         )}
       </div>
-      <h2>{currentDate()} 날씨입니다</h2>
       <JpHourlyWeather days={forecast} />
-      <JpForecastWeather days={weatherData} />
-
-      <ul className='weather-where'>
-        {cities.kr.map((krCity, index) => (
-          <li
-            className='weather-city'
-            key={krCity}
-            onClick={(e) => {
-              setCity(e.target.innerText);
-              fetchWeatherData(cities.us[index]);
-            }}
-          >
-            {krCity}
-          </li>
-        ))}
-      </ul>
+      <JpForecastWeather days={forecast} />
+      <div className='jp-weather-where-container'>
+        <h2 className='jp-where'>어디로 놀러가시나요?</h2>
+        <ul className='jp-weather-where'>
+          {cities.kr.map((krCity, index) => (
+            <li
+              className='jp-weather-city'
+              key={krCity}
+              onClick={(e) => {
+                setCity(e.target.innerText);
+                fetchWeatherData(cities.us[index]);
+              }}
+            >
+              {krCity}
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }

--- a/src/components/Korea/KoreaDefaultLayout.css
+++ b/src/components/Korea/KoreaDefaultLayout.css
@@ -5,9 +5,9 @@
   height: 100vh;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
+  /* 화면의 위부터 아래로 모든 컨텐츠가 표시되도록 수정하였습니다 */
   align-items: center;
-  border: 3px solid red;
   overflow-y: auto;
   /* 최대 길이에 맞춰 스크롤이 작동하도록 했습니다 */
   /* navbar가 화면에 보일 수 있는 여유를 줬습니다 */
@@ -15,15 +15,16 @@
 }
 
 .korea-footer {
-  border: 3px solid red;
   position: fixed;
-  display: flex;
   /* 위치 고정 */
+  display: flex;
+  align-items: center;
   bottom: 0;
+  /* 화면 최하단 표시 */
   z-index: 99;
   height: 10vh;
-  align-items: center;
-  /* 최상단 표시 */
+  background-color: #ffffff;
+  box-shadow: 0 0 5px #00000013;
 }
 
 .korea-navbar {
@@ -44,25 +45,78 @@
   text-align: center;
 }
 
-.korea-weather-hourly {
-  display: flex;
-  flex-direction: row;
-  padding: 0;
-  margin: 0;
-  border: 2px solid red;
+.kr-weather-text-div {
   max-width: 480px;
   width: 100vw;
+  text-align: center;
+  border-radius: 25px;
+}
+
+.kr-weather-text1 {
+  color: #087953e9;
+  font-size: 30px;
+  font-weight: 400;
+  margin-top: 40px;
+  margin-bottom: 0;
+}
+
+.kr-weather-text2 {
+  color: #0000009e;
+  font-size: 18px;
+  font-weight: 500;
+  margin-top: 5px;
+}
+
+.kr-weather-current {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.kr-weather-current .city {
+  font-size: 38px;
+  font-weight: 400;
+}
+
+.kr-weather-current .c {
+  font-size: 68px;
+  margin: 0;
+  font-weight: 500;
+}
+
+.kr-weather-current .text {
+  font-size: 18px;
+  text-transform: uppercase;
+  color: #00000055;
+}
+
+.korea-weather-hourly {
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: row;
+  padding: 0px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  margin: 0;
+  max-width: 460px;
+  width: 95vw;
   box-sizing: border-box;
-  /* 화면 밖으로 벗어나지 않도록, 어떤 디바이스에서도 동일한 환경을 제공하도록 수정하였습니다 */
   height: 100px;
   text-align: center;
   flex-wrap: nowrap;
   overflow-y: hidden;
   overflow-x: auto;
-  /* scroll 관련 기능 */
+  list-style-type: none;
+  border-radius: 15px;
+  box-shadow: 0 0 5px #00000033;
 }
 
-.korea-weather-hourly div {
+.korea-weather-hourly li {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
   flex: 0 0 auto;
   margin: 10px;
 }
@@ -72,6 +126,77 @@
 }
 
 .korea-weather-hourly-icon {
-  width: 42px;
-  height: 42px;
+  width: 38px;
+}
+
+.korea-forecast {
+  background-color: #ffffff;
+  padding: 0;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  max-width: 460px;
+  width: 95vw;
+  list-style-type: none;
+  display: flex;
+  flex-direction: column;
+  border-radius: 15px;
+  box-shadow: 0 0 5px #00000033;
+}
+
+.korea-forecast li {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  border-bottom: 1px solid #00000013;
+}
+
+.korea-forecast .last {
+  border-bottom: none;
+}
+
+.korea-forecast img {
+  width: 28px;
+}
+
+.kr-weather-where-container {
+  max-width: 480px;
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-radius: 25px;
+}
+
+.kr-where {
+  color: #008138c1;
+  font-weight: 400;
+  text-align: center;
+}
+
+.kr-weather-where {
+  padding: 0;
+  max-width: 460px;
+  width: 95vw;
+  list-style-type: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.kr-weather-city {
+  background-color: #ffffff;
+  text-align: center;
+  font-size: 20px;
+  font-weight: 400;
+  color: #000000;
+  border-radius: 18px;
+  box-shadow: 0 0 3px #00000033;
+  margin: 7px 10px;
+  padding: 8px 18px;
+  cursor: pointer;
+}
+
+.kr-weather-city:hover {
+  background-color: #00000018;
+  transition: 0.5s;
 }

--- a/src/components/Korea/KrWeather/KrForecastWeather.jsx
+++ b/src/components/Korea/KrWeather/KrForecastWeather.jsx
@@ -1,5 +1,30 @@
-function KrForecastWeather() {
-  return <div>KrForecastWeather</div>;
+function KrForecastWeather({ days }) {
+  if (days === '') {
+    return null;
+  }
+
+  return (
+    <ul className='korea-forecast'>
+      <li>
+        <span>오늘</span>
+        <img src={days[0].day.condition.icon}></img>
+        <span>{days[0].day.mintemp_c}°</span>
+        <span>{days[0].day.maxtemp_c}°</span>
+      </li>
+      <li>
+        <span>내일</span>
+        <img src={days[1].day.condition.icon}></img>
+        <span>{days[1].day.mintemp_c}°</span>
+        <span>{days[1].day.maxtemp_c}°</span>
+      </li>
+      <li className='last'>
+        <span>모래</span>
+        <img src={days[2].day.condition.icon}></img>
+        <span>{days[2].day.mintemp_c}°</span>
+        <span>{days[2].day.maxtemp_c}°</span>
+      </li>
+    </ul>
+  );
 }
 
 export default KrForecastWeather;

--- a/src/components/Korea/KrWeather/KrWeather.jsx
+++ b/src/components/Korea/KrWeather/KrWeather.jsx
@@ -42,36 +42,38 @@ function KrWeather() {
 
   return (
     <div className='weather'>
-      <h2>한국 날씨입니다</h2>
-      <div className='weather-current'>현재 날씨</div>
+      <div className='kr-weather-text-div'>
+        <h2 className='kr-weather-text1'>한국</h2>
+        <h2 className='kr-weather-text2'>{weatherData && `${currentDate()} 날씨`}</h2>
+      </div>
       <div>
         {weatherData && (
-          <div>
-            <h2>{city}</h2>
-            <img src={weatherData.current.condition.icon}></img>
-            <p>{weatherData.current.feelslike_c}</p>
-            <p>{weatherData.current.condition.text}</p>
+          <div className='kr-weather-current'>
+            <h2 className='city'>{city}</h2>
+            <p className='c'>{weatherData.current.feelslike_c}°</p>
+            <p className='text'>{weatherData.current.condition.text}</p>
           </div>
         )}
       </div>
-      <h2>{currentDate()} 날씨입니다</h2>
       <KrHourlyWeather days={forecast} />
-      <KrForecastWeather days={weatherData} />
-
-      <ul className='weather-where'>
-        {cities.kr.map((krCity, index) => (
-          <li
-            className='weather-city'
-            key={krCity}
-            onClick={(e) => {
-              setCity(e.target.innerText);
-              fetchWeatherData(cities.us[index]);
-            }}
-          >
-            {krCity}
-          </li>
-        ))}
-      </ul>
+      <KrForecastWeather days={forecast} />
+      <div className='kr-weather-where-container'>
+        <h2 className='kr-where'>국내도 즐겁죠!</h2>
+        <ul className='kr-weather-where'>
+          {cities.kr.map((krCity, index) => (
+            <li
+              className='jp-weather-city'
+              key={krCity}
+              onClick={(e) => {
+                setCity(e.target.innerText);
+                fetchWeatherData(cities.us[index]);
+              }}
+            >
+              {krCity}
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
![화면 기록 2023-10-18 오전 4 53 29](https://github.com/2-guys-Javascript/travel-web-app/assets/130689753/850aba42-3901-4c78-8219-5ee1ad589c35)

# 🌦️ ForecastWeather 컴포넌트 완성
3일간 (무료가 3일 밖에 안되네요..) 일기 예보를 불러오는 컴포넌트를 만들었습니다! 7일 정도의 데이터를 가져올 수 있었다면 좋았을텐데 좀 아쉽네요.. 무료로 날씨 정보를 주는 다른 API도 최대 4~5일이 많더라구요. 하루 이틀 더 늘리겠다고 갈아엎기도 그래서 그냥 했습니다,, 😩

# 🎨 CSS 수정
좀 더 네이티브한 앱스럽게 날씨 컴포넌트 안의 CSS를 수정 해봤습니다! 추가된 코드량이 많이서 당황 스러우실 것 같은데, 한번 쭉 훑어만 보시면 계속 반복되는 패턴이라 이해가 금방 될거에요! 
원래는 뭐 background color 도 넣어봤다가.. 그라데이션도 넣어봤다가 했지만, 결국 미니멀한 디자인이 가장 질리지 않고 촌스러운 느낌이 덜한 것 같아서 다 빼고 심플하게 했습니다..!
어차피 나중에 다 어느 정도 통일감을 위해 수정이 되기도 할거라 크게 디테일한 부분은 건들이지 않았습니다!
확인해보시고 보다 더 나은 방향에 대해서 제시 해주시면 감사하겠습니다..!! 