### PR TITLE
🎨 Styles: get away scroll bar and added comments

### DIFF
--- a/src/components/Japan/Exchange.jsx
+++ b/src/components/Japan/Exchange.jsx
@@ -35,6 +35,7 @@ function Exchange() {
     setIsKrwToJpy(!isKrwToJpy);
   }
 
+  // 첫 화면이 나타날 때 환율을 구하는 함수들이 한번씩 실행됨
   useEffect(() => {
     getKrwToJpyExchange();
     getJpyToKrwExchange();

--- a/src/components/Japan/JapanDefaultLayout.css
+++ b/src/components/Japan/JapanDefaultLayout.css
@@ -165,6 +165,7 @@
   text-align: center;
 }
 
+/* ul 태그에 적용되는 css이며 리스트 타입은 없이, wrap으로 자동으로 아래로 넘겨주었다 */
 .jp-weather-where {
   padding: 0;
   max-width: 460px;
@@ -214,7 +215,7 @@
 }
 
 .real-exchangeRate:hover {
-  box-shadow: 0px 0px 30px #f7bee7;
+  box-shadow: 0px 0px 30px #00000018;
 }
 
 .real-exchangeRate:hover {

--- a/src/components/Japan/JpDefaultLayout.jsx
+++ b/src/components/Japan/JpDefaultLayout.jsx
@@ -4,7 +4,7 @@ import JpNavBar from './JpNavBar';
 
 function JpDefaultLayout() {
   return (
-    <div className='jp-default-layout'>
+    <div className='jp-default-layout scroll-box'>
       <Outlet />
       <JpNavBar />
     </div>

--- a/src/components/Japan/JpWeather/JpForecastWeather.jsx
+++ b/src/components/Japan/JpWeather/JpForecastWeather.jsx
@@ -1,3 +1,4 @@
+// 오늘, 내일, 모레에 대한 기상 예보를 나타내는 컴포넌트
 function JpForecastWeather({ days }) {
   if (days === '') {
     return null;

--- a/src/components/Japan/JpWeather/JpHourlyWeather.jsx
+++ b/src/components/Japan/JpWeather/JpHourlyWeather.jsx
@@ -1,10 +1,11 @@
+// 사용자가 애플리케이션을 사용하는 당일에 대한 시간대별 날씨 정보 컴포넌트
 function JpHourlyWeather({ days }) {
   if (days === '') {
     return null;
   }
 
   return (
-    <ul className='japan-weather-hourly'>
+    <ul className='japan-weather-hourly scroll-box'>
       {days[0].hour.map((hour) => (
         <li key={hour.time.slice(10, 13)}>
           <p> {hour.time.slice(10, 13)}시 </p>

--- a/src/components/Japan/JpWeather/JpWeather.jsx
+++ b/src/components/Japan/JpWeather/JpWeather.jsx
@@ -7,6 +7,8 @@ function JpWeather() {
   const [weatherData, setWeatherData] = useState('');
   // 사용자가 선택한 도시의 이름을 나타내는 상태
   const [city, setCity] = useState('');
+  // 사용자가 api 요청을 오늘, 내일, 그리고 모레에 대한 3일을 기준으로 날리기에 길이가 3짜리인 배열 상태가 될 것임
+  // 해당 상태는 JpHourlyWeather와 JpForecastWeather에 모두 days 라는 prop으로 전달
   const [forecast, setForecast] = useState('');
 
   // 현재 웹 애플리케이션에서 UI에 활용하는 이름은 한글이지만, fetch 요청을 날릴 때, q 매개변수에 필요한 것은 영문 도시명이기에 필요
@@ -35,10 +37,8 @@ function JpWeather() {
       const result = await response.json();
       setWeatherData(result);
       setForecast(result.forecast.forecastday.map((day) => day));
-      console.log(result.forecast.forecastday.map((day) => day));
     } catch (error) {
       setWeatherData(null);
-      console.error(error);
     }
   };
 
@@ -57,6 +57,7 @@ function JpWeather() {
           </div>
         )}
       </div>
+      {/* JpHourWeather과 JpForecastWeather 컴포넌트는 prop으로 전달된 days가 빈 문자열이면 null 반환으로 UI로 나타나지 않음 */}
       <JpHourlyWeather days={forecast} />
       <JpForecastWeather days={forecast} />
       <div className='jp-weather-where-container'>

--- a/src/components/Korea/KrDefaultLayout.jsx
+++ b/src/components/Korea/KrDefaultLayout.jsx
@@ -4,7 +4,7 @@ import KrNavBar from './KrNavBar';
 
 function KrDefaultLayout() {
   return (
-    <div className='kr-default-layout'>
+    <div className='kr-default-layout scroll-box'>
       <Outlet />
       <KrNavBar />
     </div>

--- a/src/components/Korea/KrWeather/KrHourlyWeather.jsx
+++ b/src/components/Korea/KrWeather/KrHourlyWeather.jsx
@@ -4,7 +4,7 @@ function KrHourlyWeather({ days }) {
   }
 
   return (
-    <ul className='korea-weather-hourly'>
+    <ul className='korea-weather-hourly scroll-box'>
       {days[0].hour.map((hour) => (
         <li key={hour.time.slice(10, 13)}>
           <img className='korea-weather-hourly-icon' src={hour.condition.icon} />

--- a/src/index.css
+++ b/src/index.css
@@ -19,3 +19,12 @@ body {
   align-items: center;
   padding-bottom: 90px;
 }
+
+/* 아래의 두 설정은 scroll-box 라는 클래스를 가진 요소들에게 스크롤은 되지만, 스크롤 바는 없애는 설정이다 */
+.scroll-box {
+  -ms-overflow-style: none;
+}
+
+.scroll-box::-webkit-scrollbar{
+  display:none;
+}


### PR DESCRIPTION
![testApp](https://github.com/2-guys-Javascript/travel-web-app/assets/125981945/37a1e190-5374-4d28-95f0-002cf5727892)
1. 날씨 탭에에서 특정 도시를 눌렀을 때, footer가 살짝 왼쪽으로 이격되는 현상이 있었습니다. footer에 `position: fixed` 속성을 부여했음에도 이러한 일이 벌어지는 것은, 특정 도시의 날씨 예보를 보고자 버튼을 누르면 `Layout` 컴포넌트에 스크롤 바가 생성되기 때문입니다. 이는 스크롤이라는 기능 이외에도 scroll bar 자체가 일종의 padding을 만들어주고, footer는 fixed 되어 있지만 결국 레이아웃의 자식 요소이기에 영향을 받는 것입니다. 따라서 이를 해결하기 위해 레이아웃 컴포넌트에 `scroll-box` 라는 클래스를 부여해주고, index.css 파일에서 관련된 설정을 만들어 주었습니다(한국 탭에도 이를 통일성 있게 적용해야하기 떄문에). 또한 `hourly-weather` UI에도 같은 클래스 명을 부여하여 여기에서도 스크롤은 되지만 스크롤 바는 없애는 것을 구현하여 세련됨을 높였습니다.
2. 여기 저기 파일에 나중에 코드를 들여다볼 때 도움이 될 수 있도록 주석을 좀 달았습니다. 