### PR TITLE
⚒️ Refactor: align text of exchange component

### DIFF
--- a/src/components/Japan/Exchange.jsx
+++ b/src/components/Japan/Exchange.jsx
@@ -45,7 +45,7 @@ function Exchange() {
     <div className='exchange-outer-div'>
       <h2 className='exchange-description'>일본 환율 화면입니다</h2>
       <div className='real-exchangeRate' onClick={handleChangeKrwJpy}>
-        <div>Click here to change a base currency
+        <div className='exchange-click-description'>Click to change a base currency
           <h4 className='base-currency'>Base currency is {isKrwToJpy === true? 'Yen': 'Won'}</h4>
         </div>
         <h2>{isKrwToJpy === true ? `${krwToJpy['conversion_rate']}₩` : `${jpyToKrw['conversion_rate']}¥`}</h2>

--- a/src/components/Japan/JapanDefaultLayout.css
+++ b/src/components/Japan/JapanDefaultLayout.css
@@ -97,6 +97,10 @@
   cursor: pointer;
 }
 
+.exchange-click-description {
+  text-align: center;
+}
+
 .base-currency {
   text-align: center;
 }


### PR DESCRIPTION
아이폰 환경으로 환율 UI를 보았을 때 텍스트가 왼쪽으로 쏠리는 현상을 해결했습니다!