### PR TITLE
✨ Feat : make LoginMap connect to firebase

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -63,7 +63,19 @@ function App() {
             />
           }
         >
-          <Route path='/japan' element={<Japan />} />
+          <Route
+            path='/japan'
+            element={
+              <Japan
+                isLoggedIn={isLoggedIn}
+                onChangeIsLoggedIn={setIsLoggedIn}
+                userId={userId}
+                onChangeUserId={setUserId}
+                displayName={displayName}
+                onChangeDisplayName={setDisplayName}
+              />
+            }
+          />
           <Route path='/japan/weather' element={<JpWeather />} />
           <Route path='/japan/exchange' element={<Exchange />} />
         </Route>

--- a/src/components/Japan/Japan.jsx
+++ b/src/components/Japan/Japan.jsx
@@ -1,9 +1,21 @@
 import LoginMap from '../Maps/LoginMap';
+import NonLoginMap from '../Maps/NonLoginMap';
 
-function Japan() {
+function Japan({ isLoggedIn, onChangeIsLoggedIn, userId, onChangeUserId, displayName, onChangeDisplayName }) {
   return (
     <>
-      <LoginMap />
+      {isLoggedIn ? (
+        <LoginMap
+          isLoggedIn={isLoggedIn}
+          onChangeIsLoggedIn={onChangeIsLoggedIn}
+          userId={userId}
+          onChangeUserId={onChangeUserId}
+          displayName={displayName}
+          onChangeDisplayName={onChangeDisplayName}
+        />
+      ) : (
+        <NonLoginMap />
+      )}
       <div>This is Japan</div>
     </>
   );

--- a/src/components/Maps/CreateMarkerForm.jsx
+++ b/src/components/Maps/CreateMarkerForm.jsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 import './Map.css';
 
 // onCreateMarker는 handleCreateMarker() 함수가 전달된 것으로 폼 정보만 인자로 넣기
-function CreateMarkerForm({ onCreateMarker }) {
+function CreateMarkerForm({ onCreateMarker, userId }) {
   const [dateValue, setDateValue] = useState(new Date());
 
   function handleSubmitForm(ev) {

--- a/src/components/Maps/LoginMap.jsx
+++ b/src/components/Maps/LoginMap.jsx
@@ -2,6 +2,9 @@ import { useState, useCallback, memo, useEffect } from 'react';
 import { GoogleMap, useJsApiLoader, MarkerF, InfoWindow, InfoWindowF } from '@react-google-maps/api';
 import CreateMarkerForm from './CreateMarkerForm';
 import MarkerInfo from './MarkerInfo';
+import moment from 'moment';
+import { db } from '../../../firebaseConfig';
+import { getDoc, doc, updateDoc, setDoc } from 'firebase/firestore';
 import './Map.css';
 
 let center = { lat: 37.49, lng: 127.02 };
@@ -18,12 +21,17 @@ const myStyles = [
   },
 ];
 
-function LoginMap() {
+function LoginMap({ isLoggedIn, onChangeIsLoggedIn, userId, onChangeUserId, displayName, onChangeDisplayName }) {
   const [markers, setMarkers] = useState([]);
   const [map, setMap] = useState(null);
-  const [userLocation, setUserLocation] = useState(null); // 현재 위치를 받아올 상태
-  const [creatingMarker, setCreatingMarker] = useState(false); // 마커를 만드는 중인지
-  const [selectedMarker, setSelectedMarker] = useState(null); // 저장된 마커의 정보를 보여줄 마커
+  // 현재 위치를 받아올 상태
+  const [userLocation, setUserLocation] = useState(null);
+  // 마커를 만드는 중인지
+  const [creatingMarker, setCreatingMarker] = useState(false);
+  // 저장된 마커의 정보를 보여줄 마커
+  const [selectedMarker, setSelectedMarker] = useState(null);
+  // 현재 날짜를 나타낼 상태에 해당합니다. 이는 useEffect의 의존성으로 사용되어 바뀌면 새로운 데이터를 불러오게 합니다. 시작은 현재 날짜
+  const [selectedDate, setSelectedDate] = useState(moment(new Date()).format('YYYY년 MM월 DD일'));
 
   const { isLoaded } = useJsApiLoader({
     id: 'google-map-script',
@@ -53,6 +61,7 @@ function LoginMap() {
     setMap(null);
   }, []);
 
+  // 지도를 클릭했을 때, 이미 마커일정 생성 중이었으면 사라지고, 아니면 markers에 일단 추가
   const handleMapClick = (event) => {
     if (creatingMarker) {
       if (markers.length > 0) {
@@ -83,6 +92,7 @@ function LoginMap() {
     setSelectedMarker(null);
   };
 
+  // CreateMarkerForm 컴포넌트에 전달되며 새로운 마커를 보여줌
   const handleCreateMarker = (newMarkerInfo) => {
     const lat = markers[markers.length - 1].position.lat;
     const lng = markers[markers.length - 1].position.lng;
@@ -93,11 +103,33 @@ function LoginMap() {
       info: { ...newMarkerInfo },
     };
 
+    const savingObject = {};
+    savingObject[newMarker.info.title] = newMarker;
+
     setMarkers([...markers.slice(0, markers.length - 1), newMarker]);
+
+    async function pushIntoDataBase() {
+      try {
+        const documentRef = doc(db, userId, newMarker.info.date);
+        const documentSnapShot = await getDoc(documentRef);
+        if (documentSnapShot.exists()) {
+          await updateDoc(documentRef, savingObject);
+        } else {
+          await setDoc(documentRef, savingObject);
+        }
+      } catch (error) {
+        console.log(error);
+      }
+    }
+
+    pushIntoDataBase();
     setCreatingMarker(false);
   };
 
+  // 무슨 이유에서인지 모르겠으나, 일정 생성하고, 처음 해당 마커를 눌러보면 selectedMarker는 null임
+  // 따라서 바로 쓰려면 selectedMarker가 아니라, 그냥 marker를 사용하는 것이 필요함
   const handleMarkerClick = (marker) => {
+    console.log(markers);
     if (creatingMarker) {
       // 생성 중인 마커를 클릭하면 해당 마커를 삭제
       if (markers.length > 0) {
@@ -105,14 +137,45 @@ function LoginMap() {
       }
       setCreatingMarker(false);
     }
-    setSelectedMarker(marker);
+    setSelectedMarker({ ...marker });
     map.panTo(marker.position);
     console.log(marker);
+    console.log(selectedMarker);
   };
+
+  const handleDateChange = (ev) => {
+    setSelectedDate(moment(ev.target.value).format('YYYY년 MM월 DD일'));
+  };
+
+  // handleMapClick 함수의 처음 조건에 걸리지 않게 creatingMarker를 false로 만들어줬어요
+  useEffect(() => {
+    setMarkers([]);
+    setCreatingMarker(false);
+    const fetchMarkersData = async () => {
+      try {
+        const documentRef = doc(db, userId, selectedDate);
+        const snapShot = await getDoc(documentRef);
+        const fetchedDocument = snapShot.data();
+        const markerArray = [];
+        for (const myKey in fetchedDocument) {
+          markerArray.push(fetchedDocument[myKey]);
+        }
+        setMarkers(markerArray);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    fetchMarkersData();
+    console.log(markers);
+  }, [selectedDate]);
 
   return isLoaded ? (
     <div className='map-display'>
       <div>지도화면입니다</div>
+      <div>
+        <input type='date' onChange={handleDateChange} />
+      </div>
       <GoogleMap
         mapContainerClassName='map-container'
         center={userLocation || center}
@@ -131,7 +194,7 @@ function LoginMap() {
           />
         ))}
       </GoogleMap>
-      {creatingMarker && <CreateMarkerForm onCreateMarker={handleCreateMarker} />}
+      {creatingMarker && <CreateMarkerForm onCreateMarker={handleCreateMarker} userId={userId} />}
       {selectedMarker && <MarkerInfo marker={selectedMarker} onClose={() => setSelectedMarker(null)} />}
     </div>
   ) : (

--- a/src/components/Maps/Map.css
+++ b/src/components/Maps/Map.css
@@ -12,7 +12,7 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding-bottom: 64px;
+  padding-bottom: 10vh;
 }
 
 .create-marker-form {


### PR DESCRIPTION
작동 영상의 GIF는 용량이 다소 큰 점이 있어 동준님께 카톡으로 보낸 영상으로 대체하도록 하겠습니다!

___
1. 비로그인, 로그인 컴포넌트의 구분 📌
[해당 코드](https://github.com/Programming-Seungwan/travel-web-app_fork_seungwan/blob/c9fbfcc536561772b2904f5b7e0db858fe3e0ffe/src/components/Japan/Japan.jsx#L7-L18) 에서 보시는 바와 같이 현재 로그인 된 사용자는 `LogInMap` 컴포넌트를, 안된 사용자는 `NonLogInMap` 컴포넌트를 보여줍니다.
___
2. firebase의 데이터 모델링 🩻
<img width="2048" alt="스크린샷 2023-10-24 오전 3 07 35" src="https://github.com/2-guys-Javascript/travel-web-app/assets/125981945/46d1a35c-a760-4323-a8d5-7cd2f6ab581e">

현재 보시는 이미지를 참고하시면 좋을 것 같습니다. 
저희가 사전에 토의한 내용대로, 우선 데이터베이스 내 컬렉션은 **사용자**입니다. 따라서 컬렉션명은 보시다시피, **userId** 상태입니다. 또한 사용자는 각각 개별 날짜에 대한 일정을 가집니다. 그래서, 컬렉션(사용자) 내 문서(document)들은 각각 하나의 날짜를 의미합니다. 그래서 사진에서 보시는 바와 같이 document의 이름이 **몇년 몇월 몇일** 로 표기가 되어있는 것입니다. 마지막으로 하나의 문서(document) 내에는
여러 일정(event)들이 필드에 맞춰 들어가 있습니다. 각 필드명은 일정(이벤트명)으로 만들어줬습니다. 왜냐하면, 하루에 같은 이벤트명은 웬만해선 만들어지지 않을 것이기 때문입니다. 하지만 추후에 이것이 별로라면 `savingObject`를 만들어줄때 `savingObject[newMarker.id]`를 이용해 웬만해선 겹치지 않는 "고도"를 식별자로 사용할 수도 있을 것 같습니다(LoginMap.jsx 파일의 107 line 보시면 됩니다).
___
3.  firestore로의 접근 (**가장 중요**) 📌

우선 처음에 애플리케이션에 들어가면 오늘 날짜에 해당하는 일정을 만들어주고, 그 다음부터 날짜를 선택하면 그에 맞는 일정의 마커들을 보여주어야 한다는 원칙 아래, 상태를 만들어주었습니다. 이는 selectedDate라는 이름의 상태로 다음 코드를 보시면 됩니다. [관련 코드](https://github.com/Programming-Seungwan/travel-web-app_fork_seungwan/blob/c9fbfcc536561772b2904f5b7e0db858fe3e0ffe/src/components/Maps/LoginMap.jsx#L34).

이제 이 상태를 이용해야죠. 저는 firestore와 통신하기 위해 `useEffect()` 훅을 사용하고 그 의존성 배열로 위에서 만들어준 `selectedDate`를 활용했습니다. 즉, 날짜를 고르면 그에 맞는 데이터를 디비에서 받아오는 방식입니다. 이를 위해서 "날짜"를 문서의 id로 만들었던 것입니다. 그래야 나중에 셋독스, 겟독스, 겟독(두개는 다릅니다), 업데이트 독 등의 함수를 쓰기에 용이합니다. [관련 코드](https://github.com/Programming-Seungwan/travel-web-app_fork_seungwan/blob/c9fbfcc536561772b2904f5b7e0db858fe3e0ffe/src/components/Maps/LoginMap.jsx#L151-L171).
이 코드에서 보시다시피, useEffect 훅이 selectedDate 상태가 바뀌어서 트리거 되면, 우선 사용자에게 렌더링될 `markers` 상태를 빈 배열로 바꿉니다. 그리고 `setCreatingMarker(false)` 도 해주고요. 왜냐면 나중에 handleMapClick 함수한테 걸리지 않게 하기 위함입니다. 이걸 안 해주면 다른 날짜로 이동했다가 다시 돌아왔을 떄, 일단 기록된 일정은 보이지만 다른 일정을 추가하려고 지도를 "클릭"하면 기존의 일정 마커는 사라져버리거든요.

useEffect() 훅의 첫 인자 함수에서 실행되는 로직을 보시면 아시겠지만, 해당 유저(userId)의 선택된 날짜(selectedDate)의 문서를 받아오고, 이를 스냅샷을 얻습니다. 이제 `setMarkers`를 해줄 차례죠. 근데 스냅샷은 배열입니다(여러 등록된 일정 객체들이 들어가 있는걸 확인했습니다). 그런데 for문을 돌 떄마다 그 안에서 스프레드 연산자를 이용해 상태를 바꿔주면 약간 이상하게 일부 일정 마커가 표기가 안되더라구요. 사실 이 원인은 저도 좀 더 알아봐야할 것 같습니다(콘솔 찍어보니까 객체 간에 필드 순서가 좀 다르던데,,,, 걍 이건 무시하십쇼). 그래서 저는 그냥 배열하나 딱! 만들고 for문 돌면서 그 객체들 다 `push()` 해주고 그렇게 다 만든 배열을 `setmMarker()` 의 인자로 넣어줬습니다. 어차피 새로운 배열은 메모리 내의 주소값이 달라서 이 방식은 무방하고요.

___
4. handleCreateMarker() 에서의 로직.  📌
잘 아시다시피 이 핸들러함수는 `CreateMarkerForm` 컴포넌트의 속성으로 전달되어 폼이 제출(submit)되면 트리거되는 함수입니다. 동준님께서 이 함수가 발동되면 markers 상태가 변하도록 만들어주셨죠! [관련 코드](https://github.com/Programming-Seungwan/travel-web-app_fork_seungwan/blob/c9fbfcc536561772b2904f5b7e0db858fe3e0ffe/src/components/Maps/LoginMap.jsx#L109)

위에서 말씀드렸다시피 이제 디비에 동기화를 할 차례입니다. 디비에 넣어주는건 애드 독, 셋독, 업데이트독이 있는데, 애드독은 id를 파이어베이스가 지가 만드니까 뺼게요. 근데 여기에서 아직 문서가 디비 내에 존재 안하면 `updateDoc()` 제대로 동작 안해요. 그래서 다음과 같은 코드로 짰습니다. 보시면 이해가 가실겁니다. [관련코드](https://github.com/Programming-Seungwan/travel-web-app_fork_seungwan/blob/c9fbfcc536561772b2904f5b7e0db858fe3e0ffe/src/components/Maps/LoginMap.jsx#L113-L119).

___ 
5. 수정 요망 📌
 * 우선 말씀드린대로 한국 탭에서 기록한 일정이 안나타납니다. 같은 LoginMap 컴포넌트를 쓰는데도 불구하고요. 이건 제가 한국탭에 넘길때 userId와 같은 Prop들을 아직 안 해준거 같아요
 * 쓸때없이 찍은 콘솔문을 제가 지우는걸 잊었습니다.... 이 부분도 한번 신경써주시면 감사하겠습니다.
 * 전달했지만, 사용이 안된 prop들이 다소 있습니다. 코드 지지고 볶는 와중에 막 썼다가 다시 지우고 이런 거 같아요. 이 부분도 한번 손 봐주시면 감사하겠습니다 :)


오늘 하루도 정말 고생 많으셨습니다!
