### PR TITLE
Feat: when refresh brower, login status maintain complete

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -46,7 +46,16 @@ function App() {
               />
             }
           />
-          <Route path='/korea/weather' element={<KrWeather />} />
+          <Route
+            path='/korea/weather'
+            element={
+              <KrWeather
+                onChangeIsLoggedIn={setIsLoggedIn}
+                onChangeUserId={setUserId}
+                onChangeDisplayName={setDisplayName}
+              />
+            }
+          />
         </Route>
 
         <Route
@@ -88,8 +97,26 @@ function App() {
               />
             }
           />
-          <Route path='/japan/weather' element={<JpWeather />} />
-          <Route path='/japan/exchange' element={<Exchange />} />
+          <Route
+            path='/japan/weather'
+            element={
+              <JpWeather
+                onChangeIsLoggedIn={setIsLoggedIn}
+                onChangeUserId={setUserId}
+                onChangeDisplayName={setDisplayName}
+              />
+            }
+          />
+          <Route
+            path='/japan/exchange'
+            element={
+              <Exchange
+                onChangeIsLoggedIn={setIsLoggedIn}
+                onChangeUserId={setUserId}
+                onChangeDisplayName={setDisplayName}
+              />
+            }
+          />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/App-Header/ApplicationHeader.jsx
+++ b/src/components/App-Header/ApplicationHeader.jsx
@@ -16,6 +16,10 @@ function ApplicationHeader({
     onChangeIsLoggedIn(!isLoggedIn);
     onChangeUserId('');
     onChangeDisplayName('');
+
+    localStorage.removeItem('isLoggedIn');
+    localStorage.removeItem('userId');
+    localStorage.removeItem('displayName');
   }
 
   return (

--- a/src/components/Japan/Exchange.jsx
+++ b/src/components/Japan/Exchange.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-function Exchange() {
+function Exchange({ onChangeIsLoggedIn, onChangeUserId, onChangeDisplayName }) {
   const [krwToJpy, setKrwToJpy] = useState(0);
   const [jpyToKrw, setJpyToKrw] = useState(0);
   const [isKrwToJpy, setIsKrwToJpy] = useState(true);
@@ -31,6 +31,21 @@ function Exchange() {
   useEffect(() => {
     getKrwToJpyExchange();
     getJpyToKrwExchange();
+  }, []);
+
+  useEffect(() => {
+    const storedLoginStatus = localStorage.getItem('isLoggedIn');
+    const storedUserId = localStorage.getItem('userId');
+    const storedDisplayName = localStorage.getItem('displayName');
+    console.log(storedLoginStatus);
+    console.log(storedUserId);
+    console.log(storedDisplayName);
+
+    if (storedLoginStatus) {
+      onChangeIsLoggedIn(storedLoginStatus);
+      onChangeUserId(storedUserId);
+      onChangeDisplayName(storedDisplayName);
+    }
   }, []);
 
   return (

--- a/src/components/Japan/Japan.jsx
+++ b/src/components/Japan/Japan.jsx
@@ -1,7 +1,23 @@
+import { useEffect } from 'react';
 import LoginMap from '../Maps/LoginMap';
 import NonLoginMap from '../Maps/NonLoginMap';
 
 function Japan({ isLoggedIn, onChangeIsLoggedIn, userId, onChangeUserId, displayName, onChangeDisplayName }) {
+  useEffect(() => {
+    const storedLoginStatus = localStorage.getItem('isLoggedIn');
+    const storedUserId = localStorage.getItem('userId');
+    const storedDisplayName = localStorage.getItem('displayName');
+    console.log(storedLoginStatus);
+    console.log(storedUserId);
+    console.log(storedDisplayName);
+
+    if (storedLoginStatus) {
+      onChangeIsLoggedIn(storedLoginStatus);
+      onChangeUserId(storedUserId);
+      onChangeDisplayName(storedDisplayName);
+    }
+  }, []);
+
   return (
     <>
       {isLoggedIn ? (

--- a/src/components/Japan/JpWeather/JpWeather.jsx
+++ b/src/components/Japan/JpWeather/JpWeather.jsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import JpHourlyWeather from './JpHourlyWeather';
 import JpForecastWeather from './JpForecastWeather';
 
-function JpWeather() {
+function JpWeather({ onChangeIsLoggedIn, onChangeUserId, onChangeDisplayName }) {
   const [weatherData, setWeatherData] = useState('');
   const [city, setCity] = useState('');
   // 사용자가 api 요청을 오늘, 내일, 그리고 모레에 대한 3일을 기준으로 날리기에 길이가 3짜리인 배열 상태가 될 것임
@@ -39,6 +39,21 @@ function JpWeather() {
       setWeatherData(null);
     }
   };
+
+  useEffect(() => {
+    const storedLoginStatus = localStorage.getItem('isLoggedIn');
+    const storedUserId = localStorage.getItem('userId');
+    const storedDisplayName = localStorage.getItem('displayName');
+    console.log(storedLoginStatus);
+    console.log(storedUserId);
+    console.log(storedDisplayName);
+
+    if (storedLoginStatus) {
+      onChangeIsLoggedIn(storedLoginStatus);
+      onChangeUserId(storedUserId);
+      onChangeDisplayName(storedDisplayName);
+    }
+  }, []);
 
   return (
     <div className='weather'>

--- a/src/components/Korea/Korea.jsx
+++ b/src/components/Korea/Korea.jsx
@@ -1,7 +1,22 @@
+import { useEffect } from 'react';
 import LoginMap from '../Maps/LoginMap';
 import NonLoginMap from '../Maps/NonLoginMap';
 
 function Korea({ isLoggedIn, onChangeIsLoggedIn, userId, onChangeUserId, displayName, onChangeDisplayName }) {
+  useEffect(() => {
+    const storedLoginStatus = localStorage.getItem('isLoggedIn');
+    const storedUserId = localStorage.getItem('userId');
+    const storedDisplayName = localStorage.getItem('displayName');
+    console.log(storedLoginStatus);
+    console.log(storedUserId);
+    console.log(storedDisplayName);
+
+    if (storedLoginStatus) {
+      onChangeIsLoggedIn(storedLoginStatus);
+      onChangeUserId(storedUserId);
+      onChangeDisplayName(storedDisplayName);
+    }
+  }, []);
   return (
     <>
       {isLoggedIn ? (

--- a/src/components/Korea/KrWeather/KrWeather.jsx
+++ b/src/components/Korea/KrWeather/KrWeather.jsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import KrForecastWeather from './KrForecastWeather';
 import KrHourlyWeather from './KrHourlyWeather';
 
-function KrWeather() {
+function KrWeather({ onChangeIsLoggedIn, onChangeUserId, onChangeDisplayName }) {
   const [weatherData, setWeatherData] = useState('');
   const [city, setCity] = useState('');
   const [forecast, setForecast] = useState('');
@@ -37,6 +37,21 @@ function KrWeather() {
       console.error(error);
     }
   };
+
+  useEffect(() => {
+    const storedLoginStatus = localStorage.getItem('isLoggedIn');
+    const storedUserId = localStorage.getItem('userId');
+    const storedDisplayName = localStorage.getItem('displayName');
+    console.log(storedLoginStatus);
+    console.log(storedUserId);
+    console.log(storedDisplayName);
+
+    if (storedLoginStatus) {
+      onChangeIsLoggedIn(storedLoginStatus);
+      onChangeUserId(storedUserId);
+      onChangeDisplayName(storedDisplayName);
+    }
+  }, []);
 
   return (
     <div className='weather'>

--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -15,6 +15,10 @@ function Login({ isLoggedIn, onChangeIsLoggedIn, onChangeUserId, onChangeDisplay
       onChangeUserId(user.uid);
       onChangeDisplayName(user.displayName);
       console.log(result);
+
+      localStorage.setItem('isLoggedIn', true);
+      localStorage.setItem('userId', user.uid);
+      localStorage.setItem('displayName', user.displayName);
       navigate('/home');
     } catch (error) {
       console.log(error);

--- a/src/components/Login/LoginForm.jsx
+++ b/src/components/Login/LoginForm.jsx
@@ -20,6 +20,10 @@ function LoginForm({ isLoggedIn, onChangeIsLoggedIn, onChangeUserId, onChangeDis
       onChangeIsLoggedIn(!isLoggedIn);
       onChangeUserId(user.uid);
       onChangeDisplayName(user.displayName);
+
+      localStorage.setItem('isLoggedIn', true);
+      localStorage.setItem('userId', user.uid);
+      localStorage.setItem('displayName', user.displayName);
       navigate('/home');
     } catch (error) {
       alert('Failed!');

--- a/src/components/Maps/LoginMap.jsx
+++ b/src/components/Maps/LoginMap.jsx
@@ -42,13 +42,6 @@ function LoginMap({ isLoggedIn, onChangeIsLoggedIn, userId, onChangeUserId, disp
 
   const inputRef = useRef();
 
-  const restaurantMarkerIcon = {
-    url: 'https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.freeiconspng.com%2Fimages%2Frestaurant-icon-png&psig=AOvVaw3dK8tD1vqX4A3JhwaRAAQ4&ust=1698342896236000&source=images&cd=vfe&ved=0CBEQjRxqFwoTCJD397vikYIDFQAAAAAdAAAAABAE',
-    scaledSize: new window.google.maps.Size(40, 40),
-    origin: new window.google.maps.Point(0, 0),
-    anchor: new window.google.maps.Point(20, 40),
-  };
-
   const { isLoaded } = useJsApiLoader({
     id: 'google-map-script',
     googleMapsApiKey: import.meta.env.VITE_GOOGLE_API_KEY,


### PR DESCRIPTION
기존의 웹 애플리케이션에서는 로그인을 한 뒤에도, 브라우저 새로고침을 하면 자동으로 브라우저 내 모든 메모리를 clear 하기 때문에 로그인된 상태가 튕겨버리는 한계가 있었습니다. 이에 `localStorage` 를 활용하여 새로고침을 하여 동일 요청을 보내더라도, 브라우저 내 로컬 스토리지에 저장된 로그인 관련 정보(`isLoggedIn`, `userId`, `displayName`)을 안전하게 가져와 상태를 유지하도록 만들어 주었습니다.

이를 위해 로그인, 로그아웃 과정에서 로컬 스토리지에 로그인 관련 정보를 넣고 빼는 작업이 필요합니다.
1. 로그인 할 때 : 이메일로 로그인 하는 경우(`LoginForm`)과 깃허브로 로그인 하는 경우(핸들링 함수)에서 관련 로직을 넣어주었습니다. [관련 링크1](https://github.com/Programming-Seungwan/travel-web-app_fork_seungwan/blob/ae7d0cc1b4327bca7b34ef7ec15babeb321a6f07/src/components/Login/LoginForm.jsx#L24-L26) [관련 링크2](https://github.com/Programming-Seungwan/travel-web-app_fork_seungwan/blob/ae7d0cc1b4327bca7b34ef7ec15babeb321a6f07/src/components/Login/Login.jsx#L19-L22)

2. 로그아웃할 때 : 이는 `ApplicationHeader` 컴포넌트의 로그아웃 버튼을 통해서 이루어집니다. 해당 버튼 클릭시 트리거되는 함수에 로직을 넣어줬습니다. [관련 링크](https://github.com/Programming-Seungwan/travel-web-app_fork_seungwan/blob/ae7d0cc1b4327bca7b34ef7ec15babeb321a6f07/src/components/App-Header/ApplicationHeader.jsx#L20-L22)

3. 매우 중요! 📌
사용자는 새로고침을 Japan, Korea, 날씨, 환율 탭에서 할 수 있습니다. Japan 탭과 Korea 탭은 아시다시피 지도가 나타나는 탭입니다. 해당 탭들에서 브라우저 새로고침을 한다는 것은, 위치한 url path로 요청을 다시 보낸다는 의미입니다. 하지만 기존에는 새로고침을 할때 브라우저 내 메모리가 싹다 비워져서 로그인 된 사용자도 튕겨졌습니다. 
그래서 각각의 컴포넌트들을 확인해보시면 아시겠지만, useEffect() 훅을 이용하여 해당 컴포넌트가 렌더링 될 때마다 로컬 스토리지에 있는 데이터를 가져와서 컴포넌트가 부모 컴포넌트로부터 prop으로 전달받은 상태변경함수를 통해 만들어줬습니다. 다음 코드는 공통적입니다.

```javascript
useEffect(() => {
    const storedLoginStatus = localStorage.getItem('isLoggedIn');
    const storedUserId = localStorage.getItem('userId');
    const storedDisplayName = localStorage.getItem('displayName');
    console.log(storedLoginStatus);
    console.log(storedUserId);
    console.log(storedDisplayName);

    if (storedLoginStatus) {
      onChangeIsLoggedIn(storedLoginStatus);
      onChangeUserId(storedUserId);
      onChangeDisplayName(storedDisplayName);
    }
  }, []);
``` 

감사합니다 🙇
 