### PR TITLE
🎨STYLE: 주변 카페, 음식점 정보 스타일링

### DIFF
--- a/src/components/Maps/LoginMap.css
+++ b/src/components/Maps/LoginMap.css
@@ -346,11 +346,11 @@ abbr {
   justify-content: center;
   align-items: center;
   flex-direction: column;
-  transition: transform 0.3s;
+  transition: transform 0.3s ease-out;
 }
 
 .open {
-  transform: translate(0, -130px);
+  transform: translate(0, -80px);
 }
 
 .closed {
@@ -358,25 +358,89 @@ abbr {
 }
 
 .selected-marker-info-container {
-  width: 90vw;
   max-width: 460px;
+  width: 90vw;
+  height: 120px;
   display: flex;
+  justify-content: flex-start;
   align-items: center;
-  justify-content: space-between;
-  border: 1px solid black;
+  border: 1px solid #00000055;
+  box-shadow: 0 0 3px #00000033;
+  font-size: 12px;
   border-radius: 15px;
   margin-bottom: 20px;
+  padding: 10px 0;
 }
 
 .selected-marker-info-container img {
-  min-width: 100px;
-  width: 100px;
-  align-self: stretch;
+  min-width: 150px;
+  width: 150px;
+  height: 140px;
   object-fit: cover;
-  border-radius: 15px 0 0 15px;
+  border-radius: 14px 0 0 14px;
+}
+
+.selected-marker-non-img {
+  min-width: 150px;
+  width: 150px;
+  height: 140px;
+  background-color: #00000033;
+  border-radius: 14px 0 0 14px;
+  color: #000000cc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  font-size: 13px;
 }
 
 .selected-marker-information-div {
-  flex-grow: 1;
-  align-self: stretch;
+  max-width: 310px;
+  width: 90%;
+}
+
+.selected-marker-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  font-size: 10px;
+  padding: 0 20px;
+  box-sizing: border-box;
+}
+
+.selected-marker-info h2 {
+  font-size: 14px;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.selected-marker-info p {
+  height: 30px;
+}
+
+.selected-marker-info-open {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+  margin-right: 10px;
+}
+
+.selected-marker-info-open p {
+  border: 0;
+  border-radius: 8px;
+  font-size: 10px;
+  padding: 5px 7px;
+  background-color: #535353d0;
+  color: #ffffff;
+}
+
+.selected-marker-info-open .닫혔어요 {
+  background-color: #b40a0aee;
+}
+
+.selected-marker-info-open .열었어요 {
+  background-color: #13841ed0;
 }

--- a/src/components/Maps/LoginMap.jsx
+++ b/src/components/Maps/LoginMap.jsx
@@ -428,15 +428,13 @@ function LoginMap({ userId }) {
               <div className='selected-marker-info-container'>
                 <img src={selectedNearByPlace.photos[0].getUrl({ maxWidth: 150 })} />
                 <div className='selected-marker-information-div'>
-                  <h4>{selectedNearByPlace.name}</h4>
                   <SelectedPlaceInfo place={selectedNearByPlace} />
                 </div>
               </div>
             ) : (
               <div className='selected-marker-info-container'>
-                <div>등록된 사진이 없어요 😢</div>
+                <div className='selected-marker-non-img'>등록된 사진이 없어요 😢</div>
                 <div className='selected-marker-information-div'>
-                  <h4>{selectedNearByPlace.name}</h4>
                   <SelectedPlaceInfo place={selectedNearByPlace} />
                 </div>
               </div>

--- a/src/components/Maps/LoginMap.jsx
+++ b/src/components/Maps/LoginMap.jsx
@@ -305,6 +305,7 @@ function LoginMap({ userId }) {
                 setMarkers([...markers.slice(0, markers.length - 1), newMarker]);
               } else {
                 setCreatingMarker(true);
+                setContentOpen(true);
                 setMarkers([...markers, newMarker]);
               }
             }
@@ -426,7 +427,7 @@ function LoginMap({ userId }) {
           {selectedNearByPlace &&
             (selectedNearByPlace.photos && selectedNearByPlace.photos.length > 0 ? (
               <div className='selected-marker-info-container'>
-                <img src={selectedNearByPlace.photos[0].getUrl({ maxWidth: 150 })} />
+                <img src={selectedNearByPlace.photos[0].getUrl()} />
                 <div className='selected-marker-information-div'>
                   <SelectedPlaceInfo place={selectedNearByPlace} />
                 </div>

--- a/src/components/Maps/NonLoginMap.css
+++ b/src/components/Maps/NonLoginMap.css
@@ -64,7 +64,6 @@
   font-size: 10px;
   margin-top: 10px;
   border-radius: 15px;
-  /* box-sizing: border-box; */
 }
 
 .non-list:active {

--- a/src/components/Maps/SelectedPlaceInfo.jsx
+++ b/src/components/Maps/SelectedPlaceInfo.jsx
@@ -9,9 +9,11 @@ function SelectedPlaceInfo({ place }) {
 
   return (
     <div>
-      <p>{place.vicinity}</p>
-
-      <div>
+      <div className='selected-marker-info'>
+        <h2>{place.name}</h2>
+        <p>{place.vicinity}</p>
+      </div>
+      <div className='selected-marker-info-open'>
         <p className={isOpenMessage}> {isOpenMessage}</p>
       </div>
     </div>


### PR DESCRIPTION

![화면 기록 2023-11-08 오전 1 56 19](https://github.com/2-guys-Javascript/travel-web-app/assets/130689753/768b1ff5-e785-412a-9776-a83088aeedbd)


# 🎨 일정 클릭 시 주변 카페, 음식점 정보창 스타일링
일정을 클릭 했을 때 주변 카페와 음식점 정보창의 스타일을 약간 수정해줬습니다!
전체 일정 받아오는 토글 버튼이랑 받아오는걸 하려고 했는데.. 코드가 완전 꼬여갖고 싹 다 지워버렸습니다.
내일 다시 해보도록 하겠습니다... ㅠㅠ

 + 추가적으로 사진이 너무 뿌옇게 나오는 것 같아 최대 크기를 없애줬습니다!

# 🛠️ 기존 알림 기능으로 130px 위로 올라오던 일정창을 80px로 수정
지도를 너무 많이 가린다는 의견을 받아 수정하였습니다!
바로 배포 환경에 적용하도록 하겠습니다.

 + 추가적으로 검색 했을 때 열리는 creatMarker에서는 위로 살짝 올라가 알려주는 기능이 제대로 동작하지 않아 기능을 추가하였습니다!